### PR TITLE
Improve the `build-artifacts` GitHub action

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -28,12 +28,26 @@ jobs:
     - name: Build library
       run: bundle exec rake compile
 
+    - name: Set OS name
+      id: os-name
+      run: |
+        if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          echo "name=linux" >> $GITHUB_OUTPUT
+        else
+          echo "name=darwin" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Package files
+      run: |
+        mkdir dist
+        cp -r include dist/
+        cp build/libprism.a dist/
+        tar -czf prism-${{ steps.os-name.outputs.name }}.tar.gz -C dist .
+
     - name: Upload to release
       if: github.event_name == 'release'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: softprops/action-gh-release@v2
       with:
-        files: |
-          build/libprism.so
-          build/libprism.dylib
+        files: prism-${{ steps.os-name.outputs.name }}.tar.gz


### PR DESCRIPTION
1. Package the headers along with the binary
2. Package `libprism.a` instead of the dynamically built binary